### PR TITLE
feature: Add performance tracking with Firestore and chart

### DIFF
--- a/lib/features/performance_tracking/performance_chart.dart
+++ b/lib/features/performance_tracking/performance_chart.dart
@@ -1,0 +1,71 @@
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+class PerformanceChart extends StatelessWidget {
+  final List<Map<String, dynamic>> logs;
+
+  const PerformanceChart({super.key, required this.logs});
+
+  @override
+  Widget build(BuildContext context) {
+    final List<FlSpot> caloriesSpots = [];
+    final List<FlSpot> durationSpots = [];
+    final List<String> dates = [];
+
+    for (int i = 0; i < logs.length; i++) {
+      final log = logs[i];
+      caloriesSpots.add(FlSpot(i.toDouble(), log['calories_burned'].toDouble()));
+      durationSpots.add(FlSpot(i.toDouble(), log['workout_duration'].toDouble()));
+      dates.add(log['date']);
+    }
+
+    return SizedBox(
+      height: 300,
+      child: LineChart(
+        LineChartData(
+          titlesData: FlTitlesData(
+            bottomTitles: AxisTitles(
+              axisNameWidget: const Text("Date"),
+              sideTitles: SideTitles(
+                showTitles: true,
+                interval: 1,
+                getTitlesWidget: (value, meta) {
+                  int index = value.toInt();
+                  if (index >= 0 && index < dates.length) {
+                    return Text(DateFormat.Md().format(DateTime.parse(dates[index])));
+                  }
+                  return const Text('');
+                },
+              ),
+            ),
+            leftTitles: AxisTitles(
+              axisNameWidget: const Text("Calories"),
+              sideTitles: SideTitles(showTitles: true),
+            ),
+            rightTitles: AxisTitles(
+              axisNameWidget: const Text("Duration"),
+              sideTitles: SideTitles(showTitles: false),
+            ),
+          ),
+          lineBarsData: [
+            LineChartBarData(
+              spots: caloriesSpots,
+              isCurved: true,
+              color: Colors.orange,
+              barWidth: 3,
+              dotData: FlDotData(show: true),
+            ),
+            LineChartBarData(
+              spots: durationSpots,
+              isCurved: true,
+              color: Colors.blue,
+              barWidth: 3,
+              dotData: FlDotData(show: true),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/performance_tracking/performance_controller.dart
+++ b/lib/features/performance_tracking/performance_controller.dart
@@ -1,0 +1,49 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+
+class PerformanceController {
+  static final _auth = FirebaseAuth.instance;
+  static final _firestore = FirebaseFirestore.instance;
+
+  static Future<void> saveDailyLog({
+    required int calories,
+    required int duration,
+  }) async {
+    final uid = _auth.currentUser?.uid;
+    if (uid == null) throw Exception('User not logged in');
+
+    final today = DateTime.now();
+    final dateId = "${today.year}-${today.month.toString().padLeft(2, '0')}-${today.day.toString().padLeft(2, '0')}";
+
+    await _firestore
+        .collection('performance_logs')
+        .doc(uid)
+        .collection('logs')
+        .doc(dateId)
+        .set({
+      'calories_burned': calories,
+      'workout_duration': duration,
+    });
+  }
+
+  static Future<List<Map<String, dynamic>>> fetchLogs() async {
+    final uid = _auth.currentUser?.uid;
+    if (uid == null) return [];
+
+    final snapshot = await _firestore
+        .collection('performance_logs')
+        .doc(uid)
+        .collection('logs')
+        .orderBy(FieldPath.documentId)
+        .get();
+
+    return snapshot.docs.map((doc) {
+      final data = doc.data();
+      return {
+        'date': doc.id,
+        'calories_burned': data['calories_burned'],
+        'workout_duration': data['workout_duration'],
+      };
+    }).toList();
+  }
+}

--- a/lib/features/performance_tracking/performance_form.dart
+++ b/lib/features/performance_tracking/performance_form.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import 'performance_controller.dart';
+
+class PerformanceForm extends StatefulWidget {
+  final VoidCallback onSubmit;
+
+  const PerformanceForm({super.key, required this.onSubmit});
+
+  @override
+  State<PerformanceForm> createState() => _PerformanceFormState();
+}
+
+class _PerformanceFormState extends State<PerformanceForm> {
+  final _caloriesController = TextEditingController();
+  final _durationController = TextEditingController();
+  final _formKey = GlobalKey<FormState>();
+  bool isLoading = false;
+
+  Future<void> _save() async {
+    if (!_formKey.currentState!.validate()) return;
+
+    final calories = int.tryParse(_caloriesController.text);
+    final duration = int.tryParse(_durationController.text);
+
+    if (calories == null || duration == null) return;
+
+    setState(() => isLoading = true);
+
+    try {
+      await PerformanceController.saveDailyLog(
+        calories: calories,
+        duration: duration,
+      );
+      widget.onSubmit();
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text("Performance data saved!")),
+      );
+      _caloriesController.clear();
+      _durationController.clear();
+    } catch (e) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text("Error: ${e.toString()}")),
+      );
+    } finally {
+      setState(() => isLoading = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Form(
+      key: _formKey,
+      child: Column(
+        children: [
+          TextFormField(
+            controller: _caloriesController,
+            decoration: const InputDecoration(
+              labelText: "Calories Burned",
+              border: OutlineInputBorder(),
+            ),
+            keyboardType: TextInputType.number,
+            validator: (val) =>
+                val == null || val.isEmpty ? 'Enter calories' : null,
+          ),
+          const SizedBox(height: 12),
+          TextFormField(
+            controller: _durationController,
+            decoration: const InputDecoration(
+              labelText: "Workout Duration (minutes)",
+              border: OutlineInputBorder(),
+            ),
+            keyboardType: TextInputType.number,
+            validator: (val) =>
+                val == null || val.isEmpty ? 'Enter duration' : null,
+          ),
+          const SizedBox(height: 16),
+          ElevatedButton(
+            onPressed: isLoading ? null : _save,
+            child: isLoading
+                ? const CircularProgressIndicator()
+                : const Text("Save"),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/performance_tracking/performance_page.dart
+++ b/lib/features/performance_tracking/performance_page.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'performance_chart.dart';
+import 'performance_controller.dart';
+import 'performance_form.dart';
+
+class PerformancePage extends StatefulWidget {
+  const PerformancePage({super.key});
+
+  @override
+  State<PerformancePage> createState() => _PerformancePageState();
+}
+
+class _PerformancePageState extends State<PerformancePage> {
+  List<Map<String, dynamic>> logs = [];
+
+  @override
+  void initState() {
+    super.initState();
+    loadLogs();
+  }
+
+  Future<void> loadLogs() async {
+    final data = await PerformanceController.fetchLogs();
+    setState(() => logs = data);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text("Performance Tracker")),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            PerformanceForm(onSubmit: loadLogs),
+            const SizedBox(height: 24),
+            logs.isEmpty
+                ? const Text("No logs yet.")
+                : PerformanceChart(logs: logs),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'screens/splash_screen.dart';
+import 'package:Athletix/features/performance_tracking/performance_log_screen.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -21,6 +22,9 @@ class MyApp extends StatelessWidget {
         useMaterial3: true,
       ),
       home: const SplashScreen(),
+      routes: {
+        '/performance-logs': (context) => const PerformanceLogScreen(),
+      },
     );
   }
 }

--- a/lib/screens/athlete/athlete_dashboard.dart
+++ b/lib/screens/athlete/athlete_dashboard.dart
@@ -131,10 +131,7 @@ class _DashboardScreenState extends State<DashboardScreen> {
                       label: "Performance Logs",
                       color: Colors.green,
                       onTap: () {
-                        Navigator.push(
-                          context,
-                          MaterialPageRoute(builder: (_) => const PerformanceLogScreen()),
-                        );
+                        Navigator.pushNamed(context, '/performance-logs');
                       },
                     ),
                   ],

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,7 @@ dependencies:
   google_maps_flutter: ^2.5.0
   geocoding: ^2.0.4
   geolocator: ^10.0.0
+  fl_chart: ^0.64.0 
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
# 🔥 Pull Request – Athletix

Thanks for contributing to Athletix! Please complete the following to help us review your changes efficiently.

---

## 🔖 Type of Change

<!-- Select one or more -->
- [ ] 🚀 Feature – New functionality

---

## 📄 Description
## fixes : #14 
Added a new feature to allow users to log and visualize their daily performance

---

Linked to #14 

---

## 🧪 How to Test This
1. Navigate to `PerformancePage`
2. Submit workout data
3. Check Firestore
4. See updated chart

---

**Describe briefly:**
- Input form for:
  - Calories Burned
  - Workout Duration (in minutes)
- Stores data in Firestore under each user's UID
- Charts data using fl_chart package
- Supports editing/updating daily logs
---

## ✅ Checklist

- [ ] Code compiles and runs as expected
- [ ] UI works well on common device sizes
- [ ] Code follows the project’s naming & folder structure

---

