### PR TITLE
fix: improve error handling for login/signup with user-friendly dialogs

### DIFF
--- a/lib/screens/auth_screen.dart
+++ b/lib/screens/auth_screen.dart
@@ -97,8 +97,42 @@ class _AuthScreenState extends State<AuthScreen> {
         MaterialPageRoute(builder: (_) => targetScreen),
       );
     } on FirebaseAuthException catch (e) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(e.message ?? "Error")),
+      String errorMessage;
+      switch (e.code) {
+        case 'user-not-found':
+        case 'wrong-password':
+          errorMessage = "Email or password is incorrect. Please try again.";
+          break;
+        case 'invalid-email':
+          errorMessage = "The email address is not valid.";
+          break;
+        case 'user-disabled':
+          errorMessage = "This user account has been disabled.";
+          break;
+        case 'email-already-in-use':
+          errorMessage = "This email is already registered. Try logging in.";
+          break;
+        case 'weak-password':
+          errorMessage = "Your password must be at least 8 characters and contain a number.";
+          break;
+        case 'operation-not-allowed':
+          errorMessage = "This operation is not allowed. Please contact support.";
+          break;
+        default:
+          errorMessage = e.message ?? "An unknown error occurred. Please try again.";
+      }
+      showDialog(
+        context: context,
+        builder: (context) => AlertDialog(
+          title: const Text('Authentication Error'),
+          content: Text(errorMessage),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('OK'),
+            ),
+          ],
+        ),
       );
     }
   }


### PR DESCRIPTION
# 🔥 Pull Request – Athletix

Thanks for contributing to Athletix! Please complete the following to help us review your changes efficiently.

---

## 🔖 Type of Change

<!-- Select one or more -->
- [ ] 🚀 Feature – New functionality
- [ ✓] 🐛 Fix – Bug fix
- [ ] 🧹 Refactor – Code clean-up (no new features)
- [ ] 🧪 Test – Added/updated tests
- [ ] 📝 Docs – Documentation changes

---

## 📄 Description

Replaced raw Firebase error messages with more user-friendly dialog boxes during login and signup.

Helps users understand issues like incorrect credentials, weak passwords, or already registered emails.

Uses showDialog() to display alerts based on Firebase exceptions.
- 

---

## 🎯 Related Issue

Fixes #18 

---

## 🧪 How to Test This

Navigate to: lib/screens/auth_screen.dart

Try:

- Logging in with wrong credentials
- Signing up with a weak password
- Signing up with an already registered email

Expected behavior:

- Dialog box appears with a clear message such as:
        -   "Email or password is incorrect."
        -   "Password must be at least 6 characters."
        -   "This email is already registered."

Tested on:
- [ ✓] Android Emulator
- [ ] Android Physical Device
- [ ] iOS Simulator/Device (optional)

---

## 📸 UI Changes (if applicable)

<!-- Add relevant screenshots or a short screen recording -->
| Before | After |
|--------|-------|
|        |       |

---

## 🔐 Firebase / Firestore Updates

<!-- If this PR touches Firebase or Firestore config/structure -->
- [ ] New Firestore collection or document
- [ ] Changed Firebase rules
- [ ✓] Updated Auth or FCM logic

**Describe briefly:**

---

## ✅ Checklist

- [ ✓] Code compiles and runs as expected
- [ ✓] UI works well on common device sizes
- [ ✓] No debug prints or commented code
- [✓ ] Ran `flutter pub get` and `flutter format .`
- [ ✓] Code follows the project’s naming & folder structure
- [✓ ] No sensitive keys or secrets in code
- [✓ ] Documentation/code comments updated (if needed)

---

## 🙋 Additional Notes

<!-- Add anything else reviewers should know -->
-
